### PR TITLE
fixed inverse_spectrum_truncation expecting an integer

### DIFF
--- a/pycbc/4_ChisqSignificance.ipynb
+++ b/pycbc/4_ChisqSignificance.ipynb
@@ -137,7 +137,7 @@
     "    # resolving narrow lines becomes more difficult.\n",
     "    p = data[ifo].psd(2)\n",
     "    p = interpolate(p, data[ifo].delta_f)\n",
-    "    p = inverse_spectrum_truncation(p, 2 * data[ifo].sample_rate, low_frequency_cutoff=15.0)\n",
+    "    p = inverse_spectrum_truncation(p, int(2 * data[ifo].sample_rate), low_frequency_cutoff=15.0)\n",
     "    psd[ifo] = p\n",
     "    \n",
     "    pylab.plot(psd[ifo].sample_frequencies, psd[ifo], label=ifo)\n",


### PR DESCRIPTION
Hi @jkanner 

This is Marco from ODW 2024 in Taiwan :o)
I have been curious replaying some of the old ODW2018 notebooks.

The chi2 test notebook complains about the value passed into inverse_spectrum_truncation being a float instead of an integer. I just fix it. 

Thank you again for your great work, this is very valuable resources for teaching..